### PR TITLE
WEBDEV-1263: We don't receive Slack notifications about PR with fixed tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,7 +54,9 @@ try {
     const pr = payload.pull_request;
     let message;
 
-    if (!review && payload.action !== "ready_for_review" && payload.action !== "opened") {
+    // We don't need to check this at all, because we call slack-notify action only after all checks in our CI.
+    // Feel free to delete this condition in the future.
+    if (!review && !["ready_for_review", "opened", "synchronize", "reopened"].includes(payload.action)) {
         return
     }
 


### PR DESCRIPTION
## [WEBDEV-1263](https://intelas.atlassian.net/browse/WEBDEV-1263)
### Problem
We don't receive Slack notifications that originally failed tests but then got test fixes.
### Solution
I added new pull_request action types from our WEB repo into the check inside of this repo.